### PR TITLE
请求时参数params拷贝传入参数而不是引用

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -33,25 +33,26 @@ var Http = /** @class */ (function () {
                 ? relativeUrl
                 : _this.hostUrl +
                     (relativeUrl[0] === "/" ? relativeUrl : "/" + relativeUrl);
+            var paramsCopy = JSON.parse(JSON.stringify(params));
             var valueChangePostParams = {
                 url: url,
                 relativeUrl: relativeUrl,
                 method: method,
-                params: params,
+                params: paramsCopy,
                 params2: params2,
             };
             _this.httpSendBeforeHook.next(valueChangePostParams);
             params2 = _this.appendParams2(params2, method);
-            _this.beforeFn && _this.beforeFn(params, params2);
+            _this.beforeFn && _this.beforeFn(paramsCopy, params2);
             var withCredentials = params2.withCredentials === undefined
                 ? _this.withCredentials
                 : params2.withCredentials;
             var httpSub = params2.notQueue
-                ? _this.http.baseHttp.send(method, url, params, params2.headers, withCredentials, params2.responseType)
+                ? _this.http.baseHttp.send(method, url, paramsCopy, params2.headers, withCredentials, params2.responseType)
                 : _this.http.xhr({
                     method: method,
                     url: url,
-                    params: params,
+                    params: paramsCopy,
                     headers: params2.headers,
                     key: params2.key,
                     withCredentials: withCredentials,
@@ -64,12 +65,12 @@ var Http = /** @class */ (function () {
                         return ob.error("over max retry");
                     if (_this.afterFn) {
                         _this.afterFn({
-                            params: params,
+                            params: paramsCopy,
                             params2: params2,
                             result: result,
                             retry: function () {
                                 params2.retryCurrent++;
-                                return _this.xhr(method, relativeUrl, params, params2);
+                                return _this.xhr(method, relativeUrl, paramsCopy, params2);
                             },
                         })
                             .then(function (resultNext) {

--- a/package/http.ts
+++ b/package/http.ts
@@ -128,18 +128,19 @@ export class Http implements HttpInterface {
         ? relativeUrl
         : this.hostUrl +
           (relativeUrl[0] === "/" ? relativeUrl : "/" + relativeUrl);
+    const paramsCopy = JSON.parse(JSON.stringify(params));
     const valueChangePostParams = {
       url,
       relativeUrl,
       method,
-      params,
+      params: paramsCopy,
       params2,
     };
 
     this.httpSendBeforeHook.next(valueChangePostParams);
     params2 = this.appendParams2(params2, method);
 
-    this.beforeFn && this.beforeFn(params, params2);
+    this.beforeFn && this.beforeFn(paramsCopy, params2);
     const withCredentials =
       params2.withCredentials === undefined
         ? this.withCredentials
@@ -148,7 +149,7 @@ export class Http implements HttpInterface {
       ? this.http.baseHttp.send(
           method,
           url,
-          params,
+          paramsCopy,
           params2.headers,
           withCredentials,
           params2.responseType,
@@ -156,7 +157,7 @@ export class Http implements HttpInterface {
       : this.http.xhr({
           method,
           url,
-          params,
+          params: paramsCopy,
           headers: params2.headers,
           key: params2.key,
           withCredentials,
@@ -174,12 +175,12 @@ export class Http implements HttpInterface {
               return ob.error("over max retry");
             if (this.afterFn) {
               this.afterFn({
-                params,
+                params: paramsCopy,
                 params2,
                 result,
                 retry: () => {
                   (params2 as any).retryCurrent++;
-                  return this.xhr(method, relativeUrl, params, params2);
+                  return this.xhr(method, relativeUrl, paramsCopy, params2);
                 },
               })
                 .then((resultNext: any) => {


### PR DESCRIPTION
防止beforeFn中对参数进行操作改变源参数